### PR TITLE
proof of concept: only spawn one webserver

### DIFF
--- a/benchmarks/.libs/legacyutils.py
+++ b/benchmarks/.libs/legacyutils.py
@@ -4,7 +4,6 @@ import sys
 
 def maybe_handle_legacy(bench_func, *args, loopsarg='loops', legacyarg=None):
     if '--legacy' not in sys.argv:
-        raise Exception("pyperformance doesn't support the pyston macrobenchmark suite yet")
         return
     argv = list(sys.argv[1:])
     argv.remove('--legacy')

--- a/benchmarks/bm_flaskblogging/run_benchmark.py
+++ b/benchmarks/bm_flaskblogging/run_benchmark.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 import os.path
 import requests
 import sys
@@ -38,23 +39,23 @@ def _bench_flask_requests(loops=1800, legacy=False):
     start = pyperf.perf_counter()
     elapsed = 0
     times = []
-    with netutils.serving(ARGV, DATADIR, "127.0.0.1:8000"):
-        requests_get = requests.get
-        for i in range(loops):
-            # This is a macro benchmark for a Python implementation
-            # so "elapsed" covers more than just how long a request takes.
-            t0 = pyperf.perf_counter()
-            requests_get("http://localhost:8000/blog/").text
-            t1 = pyperf.perf_counter()
 
-            elapsed += t1 - t0
-            times.append(t0)
-            if legacy and (i % 100 == 0):
-                print(i, t0 - start)
-        times.append(pyperf.perf_counter())
-        if legacy:
-            total = times[-1] - start
-            print("%.2fs (%.3freq/s)" % (total, loops / total))
+    requests_get = requests.get
+    for i in range(loops):
+        # This is a macro benchmark for a Python implementation
+        # so "elapsed" covers more than just how long a request takes.
+        t0 = pyperf.perf_counter()
+        requests_get("http://localhost:8000/blog/").text
+        t1 = pyperf.perf_counter()
+
+        elapsed += t1 - t0
+        times.append(t0)
+        if legacy and (i % 100 == 0):
+            print(i, t0 - start)
+    times.append(pyperf.perf_counter())
+    if legacy:
+        total = times[-1] - start
+        print("%.2fs (%.3freq/s)" % (total, loops / total))
     return elapsed, times
 
 
@@ -65,6 +66,12 @@ if __name__ == "__main__":
     from legacyutils import maybe_handle_legacy
     maybe_handle_legacy(_bench_flask_requests, legacyarg='legacy')
 
-    runner = pyperf.Runner()
-    runner.metadata['description'] = "Test the performance of flask"
-    runner.bench_time_func("flaskblogging", bench_flask_requests)
+    if "--worker" in sys.argv:
+        context = netutils.serving(ARGV, DATADIR, "127.0.0.1:8000")
+    else:
+        context = nullcontext()
+
+    with context:
+        runner = pyperf.Runner()
+        runner.metadata['description'] = "Test the performance of flask"
+        runner.bench_time_func("flaskblogging", bench_flask_requests)


### PR DESCRIPTION
@ericsnowcurrently here's a proof-of-concept of a fix to the benchmarking issue. I think a "per-worker setup+teardown" hook could be a nicer way of writing this? Or I guess it could be a "per-run setup+teardown" hook. Anyway this idea (only spawn a single webserver for the entirety of the benchmark) was what I was thinking for the general approach, I'm curious what you think is the best way to achieve this with pyperformance+pyperf.

---

Previously this benchmark would spawn a new webserver for every
call of the benchmark function, which meant that it was always
testing an un-warmed-up process. It also executed a non-deterministic
number of requests per webserver, which would affect the results
by amortizing the warmup over a different number of requests.

With this hacky change, we spawn the webserver once, and then
begin the benchmarking process against it.