### PR TITLE
Make pylint benchmark work on CPython 3.11

### DIFF
--- a/benchmarks/bm_pylint/requirements.txt
+++ b/benchmarks/bm_pylint/requirements.txt
@@ -5,4 +5,4 @@ mccabe==0.6.1
 pylint==2.6.0
 six==1.15.0
 toml==0.10.1
-wrapt==1.12.1
+wrapt==1.14.1


### PR DESCRIPTION
This just updates `wrapt` to a version that [contains fixes for CPython 3.11](https://wrapt.readthedocs.io/en/latest/changes.html).

This is part of larger work to get these benchmarks working with CPython 3.11 / pyperformance in https://github.com/faster-cpython/ideas/issues/175