### PR TITLE
Get mypy benchmark working on Python 3.11

### DIFF
--- a/benchmarks/MANIFEST
+++ b/benchmarks/MANIFEST
@@ -24,5 +24,4 @@ flaskblogging
 kinto
 
 [group all]
--mypyc
 -json

--- a/benchmarks/bm_mypy/bm_mypyc.toml
+++ b/benchmarks/bm_mypy/bm_mypyc.toml
@@ -1,9 +1,0 @@
-[project]
-name = "bm_mypyc"
-dependencies = [
-    "mypy",
-]
-dynamic = ["version"]
-
-[tool.pyperformance]
-extra_opts = ["--loops", "50"]

--- a/benchmarks/bm_mypy/requirements.txt
+++ b/benchmarks/bm_mypy/requirements.txt
@@ -1,4 +1,4 @@
-mypy==0.790
+mypy==0.961
 mypy-extensions==0.4.3
-typed-ast==1.4.1
-typing-extensions==3.7.4.3
+typed-ast==1.5.4
+typing-extensions==4.2.0

--- a/benchmarks/bm_mypy/run_benchmark.py
+++ b/benchmarks/bm_mypy/run_benchmark.py
@@ -47,7 +47,7 @@ def _bench_mypy(loops=20, *, legacy=False):
             # so "elapsed" covers more than just how long main() takes.
             t0 = pyperf.perf_counter()
             try:
-                main(None, devnull, devnull, TARGETS)
+                main(None, devnull, devnull, TARGETS, clean_exit=True)
             except SystemExit:
                 pass
             t1 = pyperf.perf_counter()


### PR DESCRIPTION
This requires:

- updating mypy
- Using the `clean_exit` kwarg so mypy doesn't call `_os.exit(0)` and deprive the chance for pyperformance to record the results. This does mean that some object destruction time may be included in the benchmark, that wouldn't normally be relevant when running mypy at the commandline. But IMHO this is fine.