### PR TITLE
Fix aiohttp benchmark on Python 3.11

### DIFF
--- a/benchmarks/bm_aiohttp/requirements.txt
+++ b/benchmarks/bm_aiohttp/requirements.txt
@@ -3,11 +3,12 @@ async-timeout==3.0.1
 attrs==20.3.0
 certifi==2020.12.5
 chardet==3.0.4
+cython==0.29.32
 gunicorn==20.0.4
 idna==2.10
 multidict==5.1.0
 requests==2.25.1
 typing-extensions==3.7.4.3
 urllib3==1.26.4
-uvloop==0.14.0
-yarl==1.6.3
+--no-binary=uvloop==0.14.0
+--no-binary=yarl==1.6.3

--- a/benchmarks/bm_aiohttp/requirements.txt
+++ b/benchmarks/bm_aiohttp/requirements.txt
@@ -11,4 +11,4 @@ requests==2.25.1
 typing-extensions==3.7.4.3
 urllib3==1.26.4
 --no-binary=uvloop==0.14.0
---no-binary=yarl==1.6.3
+yarl==1.8.1


### PR DESCRIPTION
This upgrades cython to a version that is compatible with Python 3.11, and then
uses `--no-binary` on `uvloop` and `yarl` to force a "re-Cythonization" of the
package.

I could understand if one doesn't want to merge this, since we would be testing
a local build of these packages rather than official upstream wheel. However,
this does get things working in the meantime.

EDIT: `yarl` already has a working release, so just updated to that.  `uvloop` requires this "hack" still.