### PR TITLE
Make gunicorn benchmark compatible with Python 3.11

### DIFF
--- a/benchmarks/bm_gunicorn/requirements.txt
+++ b/benchmarks/bm_gunicorn/requirements.txt
@@ -3,11 +3,12 @@ async-timeout==3.0.1
 attrs==20.3.0
 certifi==2020.12.5
 chardet==3.0.4
+cython==0.29.32
 gunicorn==20.0.4
 idna==2.10
 multidict==5.1.0
 requests==2.25.1
 typing-extensions==3.7.4.3
 urllib3==1.26.4
-uvloop==0.14.0
-yarl==1.6.3
+--no-binary=uvloop==0.14.0
+yarl==1.8.1


### PR DESCRIPTION
Exactly the same process as with `aiohttp`: Upgrade cython to one compatible with Python 3.11 and then force a re-Cythonizing of uvloop by building it from source.