### PR TITLE
Fix MANIFEST file syntax

### DIFF
--- a/benchmarks/MANIFEST
+++ b/benchmarks/MANIFEST
@@ -15,7 +15,6 @@ pytorch_alexnet_inference	<local>
 thrift	<local>
 
 [group default]
-all
 
 # These are the benchmarks that we use to measure Pyston's performance.
 [group pyston_standard]


### PR DESCRIPTION
The inclusion of the word `all` here actually just means that the default group will be filtered to only include benchmarks with the name `all`.  Obviously there aren't any by that name, so you end up just getting no benchmarks.  This fixes that.