### PR TITLE
Don't use binary wheels for mypy benchmark

### DIFF
--- a/benchmarks/bm_mypy/requirements.txt
+++ b/benchmarks/bm_mypy/requirements.txt
@@ -1,4 +1,6 @@
+--no-binary=mypy
 mypy==0.961
 mypy-extensions==0.4.3
+--no-binary=typed-ast
 typed-ast==1.5.4
 typing-extensions==4.2.0


### PR DESCRIPTION
When mypy is installed from a binary wheel, you get a `mypyc`-compiled version of mypy, otherwise, you get a pure Python version.

I would argue that it's a better benchmark of a Python implementation to be using the pure Python version.  (However, probably less useful as a benchmark of how most people run mypy in the real world).

This change would be helpful for the Faster CPython team so that we always get the pure Python version of mypy even on pre-releases of Python where wheels aren't yet published.  Obviously, it's going to significantly invalidate any baselines already computed ;)