### PR TITLE
Update for pyperformance's fixed manifest parsing

### DIFF
--- a/benchmarks/MANIFEST
+++ b/benchmarks/MANIFEST
@@ -14,13 +14,8 @@ pylint	<local>
 pytorch_alexnet_inference	<local>
 thrift	<local>
 
-[group default]
-
 # These are the benchmarks that we use to measure Pyston's performance.
 [group pyston_standard]
 djangocms
 flaskblogging
 kinto
-
-[group all]
--json


### PR DESCRIPTION
This manifest file can no longer explicitly specify `default` or `all`.  I don't think these are really used for anything here anyway, so just removing those sections makes these combinable with the pyperformance suite.