### PR TITLE
update djangocms deps to run on Python 3.12

### DIFF
--- a/benchmarks/bm_djangocms/requirements.txt
+++ b/benchmarks/bm_djangocms/requirements.txt
@@ -30,10 +30,10 @@ html5lib==1.1
 idna==2.10
 Pillow==8.0.0
 pytz==2020.1
-requests==2.24.0
-six==1.15.0
+requests==2.30.0
+six==1.16.0
 sqlparse==0.4.1
 tzlocal==2.1
 Unidecode==1.1.1
-urllib3==1.25.11
+urllib3==2.0.2
 webencodings==0.5.1


### PR DESCRIPTION
`six.moves` and `urllib3.packages.six.moves` (urllib3 vendors six) need to be on latest versions in order to work with latest Python main branch (about to become 3.12). I think this is due to recent import system deprecations/removals?

`requests` has to be upgraded along with `urllib3`.

With these updates the `djangocms` benchmark runs again on latest Python main.

There are other benchmarks that also need these dependency updates, but some of them (e.g. `flaskblogging`) seem to have other issues, so I'm just pushing the fix for djangocms for now. One step at a time!

cc @mdboom 