### PR TITLE
Fix aiohttp benchmark

### DIFF
--- a/benchmarks/bm_aiohttp/pyproject.toml
+++ b/benchmarks/bm_aiohttp/pyproject.toml
@@ -5,6 +5,7 @@ dependencies = [
     "gunicorn",
     "requests",
     "uvloop",
+    "legacy-cgi"
 ]
 dynamic = ["version"]
 

--- a/benchmarks/bm_aiohttp/requirements.txt
+++ b/benchmarks/bm_aiohttp/requirements.txt
@@ -12,3 +12,4 @@ typing-extensions==3.7.4.3
 urllib3==2.0.2
 --no-binary=uvloop==0.14.0
 yarl==1.9.2
+legacy-cgi==2.6


### PR DESCRIPTION
This requires the `cgi` stdlib module, which was removed in Python 3.13.  This just adds the `legacy-cgi` PyPI module to workaround this.