### PR TITLE
Fix gunicorn benchmark

### DIFF
--- a/benchmarks/bm_gunicorn/pyproject.toml
+++ b/benchmarks/bm_gunicorn/pyproject.toml
@@ -4,6 +4,7 @@ dependencies = [
     "gunicorn",
     "requests",
     "uvloop",
+    "legacy-cgi",
 ]
 dynamic = ["version"]
 

--- a/benchmarks/bm_gunicorn/requirements.txt
+++ b/benchmarks/bm_gunicorn/requirements.txt
@@ -11,4 +11,5 @@ requests==2.30.0
 typing-extensions==3.7.4.3
 urllib3==2.0.2
 --no-binary=uvloop==0.14.0
+legacy-cgi==2.6
 yarl==1.9.2


### PR DESCRIPTION
Similar to aiohttp, this was broken by the removal of the stdlib `cgi` module.  Adds `legacy-cgi` as a workaround.