### PR TITLE
Fix djangocms benchmark

### DIFF
--- a/benchmarks/bm_djangocms/pyproject.toml
+++ b/benchmarks/bm_djangocms/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "djangocms-snippet",
     "djangocms-style",
     "djangocms-video",
+    "legacy-cgi",
     "requests",
 ]
 dynamic = ["version"]

--- a/benchmarks/bm_djangocms/requirements.txt
+++ b/benchmarks/bm_djangocms/requirements.txt
@@ -28,6 +28,7 @@ djangocms-video==2.3.0
 easy-thumbnails==2.7
 html5lib==1.1
 idna==2.10
+legacy-cgi==2.6
 Pillow==8.0.0
 pytz==2020.1
 requests==2.30.0


### PR DESCRIPTION
This was broken by the removal of the `cgi` stdlib module in Python 3.13.  This adds `legacy-cgi` as a dependency as a workaround.