### PR TITLE
Fix pylint benchmark

### DIFF
--- a/benchmarks/bm_pylint/requirements.txt
+++ b/benchmarks/bm_pylint/requirements.txt
@@ -1,8 +1,8 @@
-astroid==2.4.2
+astroid==3.1.0
 isort==5.6.4
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
-pylint==2.6.0
+pylint==3.1.0
 six==1.15.0
 toml==0.10.1
 wrapt==1.14.1


### PR DESCRIPTION
Updates astroid and pylint to workaround the `imp` module being removed in CPython 3.12.